### PR TITLE
Add image URLs to categories in schema and seed data

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -6,6 +6,7 @@ export default defineSchema({
     name: v.string(),
     order: v.number(),
     isFood: v.boolean(),
+    imageUrl: v.optional(v.string()),
     parentId: v.optional(v.id("categories")),
   }),
 

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -10,33 +10,159 @@ const parentCategories = [
 
 const categories = [
   // Drinks section
-  { name: "Hot Coffees", order: 10, isFood: false },
-  { name: "Cold Coffees", order: 20, isFood: false },
-  { name: "Starbucks Refreshers® Beverages", order: 30, isFood: false },
-  { name: "Frappuccino® Blended Beverages", order: 40, isFood: false },
-  { name: "Iced Tea & Lemonade", order: 50, isFood: false },
-  { name: "Hot Teas", order: 60, isFood: false },
-  { name: "Iced Energy", order: 70, isFood: false },
-  { name: "Milk, Juice & More", order: 80, isFood: false },
-  { name: "Bottled Beverages", order: 90, isFood: false },
+  {
+    name: "Hot Coffees",
+    order: 10,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/bev/Cortado.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Cold Coffees",
+    order: 20,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/bev/PistachioCreamColdBrew.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Starbucks Refreshers® Beverages",
+    order: 30,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/bev/CranMerryOrangeRefresher.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Frappuccino® Blended Beverages",
+    order: 40,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/bev/FY22WIN_PistachioFrapp-onGreen.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Iced Tea & Lemonade",
+    order: 50,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/bev/SBX20190531_IcedBlackTea.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Hot Teas",
+    order: 60,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/bev/SBX20230612_6244_GingerbreadOatmilkChai-onGreen-MOP_1800.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Iced Energy",
+    order: 70,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/bev/TropicalCitrusEnergyDrink.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Milk, Juice & More",
+    order: 80,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/bev/SBX20220607_1509_PeppermintHotChocolate-onGreen-MOP_1800.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Bottled Beverages",
+    order: 90,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/bev/SpindriftLemon.jpg?impolicy=1by1_tight_288",
+  },
 
   // Food section
-  { name: "Breakfast", order: 100, isFood: true },
-  { name: "Bakery", order: 110, isFood: true },
-  { name: "Treats", order: 120, isFood: true },
-  { name: "Lunch", order: 130, isFood: true },
-  { name: "Snacks", order: 140, isFood: true },
+  {
+    name: "Breakfast",
+    order: 100,
+    isFood: true,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/food/EggPestoMozzarellaSandwich.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Bakery",
+    order: 110,
+    isFood: true,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/food/VanillaBeanCustardDanish.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Treats",
+    order: 120,
+    isFood: true,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/food/ValentinesDayCakePop-US.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Lunch",
+    order: 130,
+    isFood: true,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/food/SBX20220207_GrilledCheeseOnSourdough_US.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Snacks",
+    order: 140,
+    isFood: true,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/food/SBX20180710_PerfectBar_DarkChocolateChipPeanutButter.jpg?impolicy=1by1_tight_288",
+  },
 
   // At Home Coffee section
-  { name: "Whole Bean", order: 200, isFood: false },
-  { name: "VIA® Instant", order: 210, isFood: false },
+  {
+    name: "Whole Bean",
+    order: 200,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/at-home/SunDriedEthiopiaOromiaWestArsi-US-WBReserve.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "VIA® Instant",
+    order: 210,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/at-home/SBX20190715_ViaInstantBlondeVerandaBlend.jpg?impolicy=1by1_tight_288",
+  },
 
   // Merchandise section
-  { name: "Cold Cups", order: 300, isFood: false },
-  { name: "Tumblers", order: 310, isFood: false },
-  { name: "Mugs", order: 320, isFood: false },
-  { name: "Water Bottles", order: 330, isFood: false },
-  { name: "Other", order: 340, isFood: false },
+  {
+    name: "Cold Cups",
+    order: 300,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/merch/PURPLERECYCLDGLASSCLDCUP16OZ.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Tumblers",
+    order: 310,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/merch/PURPLERECYCLDPPTMBLR16OZ.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Mugs",
+    order: 320,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/merch/RECYCLDCERMCMUG16OZ.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Water Bottles",
+    order: 330,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/merch/SSWTRBTLTWISTTOSIPSOFTTOUCH20OZ.jpg?impolicy=1by1_tight_288",
+  },
+  {
+    name: "Other",
+    order: 340,
+    isFood: false,
+    imageUrl:
+      "https://globalassets.starbucks.com/digitalassets/products/merch/SILICONEPLUGKEYCHAINHOTCUP.jpg?impolicy=1by1_tight_288",
+  },
 ];
 
 export const seed = mutation({


### PR DESCRIPTION
- Updated schema to include optional imageUrl field for categories
- Added Starbucks product image URLs to seed data for all categories
- Expanded category definitions with representative product images